### PR TITLE
Add support bundle collection script

### DIFF
--- a/ansible/roles/vmware/files/usr/local/bin/haproxy-support
+++ b/ansible/roles/vmware/files/usr/local/bin/haproxy-support
@@ -1,0 +1,66 @@
+#!/usr/bin/env bash
+#
+# Collects support bundles for HAProxy and records networking information for debugging.
+#
+
+function save_haproxy_info {
+  # Collect HAProxy logs
+  journalctl -xu haproxy > /var/log/haproxy.log
+
+  # Collect the HAProxy version.
+  { { rpm -qa haproxy || true; } &&
+    { command -v haproxy >/dev/null 2>&1 && haproxy -vv || /usr/sbin/haproxy -vv; }; \
+  } > /etc/haproxy/haproxy-version
+
+  # Collect DPAPI version
+  { command -v dataplaneapi >/dev/null 2>&1 && dataplaneapi --version || /usr/local/bin/dataplaneapi --version; } \
+  > /etc/haproxy/dataplaneapi-version
+}
+
+function save_network_info {
+  { echo '--- IP TABLES ---' && \
+  iptables -S && \
+  echo '--- IP ADDRS ---' && \
+  ip a && \
+  echo '--- IP ROUTES ---' && \
+  ip r && \
+  echo '--- IP ROUTE TABLE LOCAL ---' && \
+  ip r show table local && \
+  echo '--- IP ROUTE TABLES ---' && \
+  grep 'rtctl_' /etc/iproute2/rt_tables | awk '{print $2}' | while IFS= read -r table_name
+  do
+    echo "${table_name}" && ip route show table "${table_name}"
+  done && \
+  echo '--- OPEN PORTS ---' && lsof -noP | grep LISTEN; } > /var/log/network-info.log
+}
+
+function save_route_table_info {
+  journalctl -xu route-tables > /var/log/routes.log
+}
+
+function save_anyip_info {
+  journalctl -xu anyip > /var/log/anyip.log
+}
+
+
+if [ "$(id -u)" != 0 ]; then
+  echo "This script must be executed as root"
+  exit 1
+fi
+
+echo "Starting support bundle collection"
+
+save_haproxy_info
+save_network_info
+save_anyip_info
+save_route_table_info
+
+support_output="${HOME}/haproxy-support.tgz"
+
+tar -C / -czf "${support_output}" \
+  /etc/haproxy \
+  /var/log/ \
+  /var/log/vmware \
+  /etc/vmware/ > /dev/null 2>&1
+
+echo "Support bundle collected at ${support_output}"

--- a/ansible/roles/vmware/tasks/main.yml
+++ b/ansible/roles/vmware/tasks/main.yml
@@ -52,6 +52,14 @@
     group: systemd-network
     mode: "0644"
 
+- name: Copy support bundle collection script
+  copy:
+    src: files/usr/local/bin/haproxy-support
+    dest: /usr/local/bin/haproxy-support
+    owner: root
+    group: root
+    mode: "0544"
+
 - name: Generate new initrd image containing our link files
   shell:
     cmd: /usr/bin/dracut --add network --rebuild /boot/initrd.img-$(uname -r)


### PR DESCRIPTION
#3 Add support bundle collection script

When debugging it's great to have a unified method of collecting
necessary support bundles for the VMware environment.

This commit adds a script to collect support bundles. It collects
information that could possibly result in a botched deployment such
as general network information, route tables, anyip configuration,
and HAProxy and Dataplane API logs.

## Verification

Deployed HAProxy and collected support bundles. Verified that the support bundles were collected successfully.
```
root@haproxy [ ~ ]# ls
haproxy-2.2.2.rpm
root@haproxy [ ~ ]# haproxy-support
Starting support bundle collection
Support bundle collected at /root/haproxy-support.tgz
root@haproxy [ ~ ]# tar xzf haproxy-support.tgz
root@haproxy [ ~ ]# ls
etc  haproxy-2.2.2.rpm  haproxy-support.tgz  var
root@haproxy [ ~ ]# find etc
etc
etc/haproxy
etc/haproxy/ca.key
etc/haproxy/ca.srl
etc/haproxy/server.key
etc/haproxy/server.crt
etc/haproxy/haproxy.cfg.lkg
etc/haproxy/.haproxy.cfg.lkg699114575
etc/haproxy/dataplaneapi-version
etc/haproxy/haproxy.cfg
etc/haproxy/dataplaneapi.cfg
etc/haproxy/ca.crt
etc/haproxy/haproxy-version
etc/vmware
etc/vmware/route-tables.cfg
etc/vmware/anyip-routes.cfg
root@haproxy [ ~ ]# find var
var
var/log
var/log/vmware-vmtoolsd-root.log
var/log/vmware-vgauthsvc.log.0
var/log/cloud-init.log
var/log/btmp
var/log/vmware-vmsvc-root.log
var/log/vmware-network.log
var/log/wtmp
var/log/haproxy.log
var/log/network-info.log
var/log/cloud-init-output.log
var/log/conntrackd-stats.log
var/log/routes.log
var/log/lastlog
var/log/vmware
var/log/vmware/net-postconfig.log
var/log/vmware/ovf-to-cloud-init.log
var/log/vmware/new_cert.log
var/log/anyip.log
var/log/private
root@haproxy [ ~ ]# cat var/log/network-info.log | grep - -A 3
--- IP TABLES ---
-P INPUT ACCEPT
-P FORWARD ACCEPT
-P OUTPUT ACCEPT
--- IP ADDRS ---
1: lo: <LOOPBACK,UP,LOWER_UP> mtu 65536 qdisc noqueue state UNKNOWN group default qlen 1000
    link/loopback 00:00:00:00:00:00 brd 00:00:00:00:00:00
    inet 127.0.0.1/8 scope host lo
--
--- IP ROUTES ---
default via 10.182.63.254 dev management proto static
10.182.48.0/20 dev management proto kernel scope link src 10.182.61.109
172.16.10.0/24 dev frontend proto kernel scope link src 172.16.10.2
--
--- IP ROUTE TABLE LOCAL ---
broadcast 10.182.48.0 dev management proto kernel scope link src 10.182.61.109
local 10.182.61.109 dev management proto kernel scope host src 10.182.61.109
broadcast 10.182.63.255 dev management proto kernel scope link src 10.182.61.109
--
--- IP ROUTE TABLES ---
rtctl_workload
default via 192.168.1.1 dev workload proto static
192.168.0.0/16 dev workload proto kernel scope link src 192.168.1.2
--
--- OPEN PORTS ---
sshd       941                            root    3u     IPv4              19584       0t0        TCP 10.182.61.109:22 (LISTEN)
dataplane 1422                            root    6u     IPv4              32303       0t0        TCP 10.182.61.109:5556 (LISTEN)
dataplane 1422 1423 dataplane             root    6u     IPv4              32303       0t0        TCP 10.182.61.109:5556 (LISTEN)
```