### PR TITLE
Add tcpdump package to set of packages installed

### DIFF
--- a/ansible/roles/common/defaults/main.yml
+++ b/ansible/roles/common/defaults/main.yml
@@ -17,6 +17,7 @@ common_photon_rpms:
 - distrib-compat
 - ebtables
 - haproxy
+- haveged
 - inotify-tools
 - iputils
 - iproute2
@@ -35,9 +36,9 @@ common_photon_rpms:
 - sed
 - socat
 - tar
+- tcpdump
 - unzip
 - vim
-- haveged
 
 disable_public_repos: false
 extra_rpms: ""


### PR DESCRIPTION
It's too useful not to have.

Minor: Move haveged up to be in alphabetical order.

Testing Done:

Built OVA using `make build-ova`. Deployed using Fusion and verified
that tcpdump was installed.

```
root@haproxy [ ~ ]# tcpdump --help
tcpdump version 4.9.3
libpcap version 1.9.1 (with TPACKET_V3)
OpenSSL 1.0.2x-fips  8 Dec 2020
Usage: tcpdump [-aAbdDefhHIJKlLnNOpqStuUvxX#] [ -B size ] [ -c count ]
                [ -C file_size ] [ -E algo:secret ] [ -F file ] [ -G seconds ]
                [ -i interface ] [ -j tstamptype ] [ -M secret ] [ --number ]
                [ -Q in|out|inout ]
                [ -r file ] [ -s snaplen ] [ --time-stamp-precision precision ]
                [ --immediate-mode ] [ -T type ] [ --version ] [ -V file ]
                [ -w file ] [ -W filecount ] [ -y datalinktype ] [ -z postrotate-command ]
                [ -Z user ] [ expression ]
```
Making sure random packet captures work
```
tcpdump -i management
...
6653 packets captured
6881 packets received by filter
224 packets dropped by kernel
```

Making sure haveged is still present
```
root@haproxy [ ~ ]# ps -A | grep haveged
  517 ?        00:00:00 haveged
root@haproxy [ ~ ]#
```