### PR TITLE
Teach HAProxy to route to multiple workload networks

### DIFF
--- a/ansible/roles/cloudinit/files/var/lib/vmware/ovf-to-cloud-init.sh
+++ b/ansible/roles/cloudinit/files/var/lib/vmware/ovf-to-cloud-init.sh
@@ -38,6 +38,8 @@ management_gw_key="network.management_gateway"
 workload_gw_key="network.workload_gateway"
 frontend_gw_key="network.frontend_gateway"
 
+workload_routes_key="network.workload.routes"
+
 # These are the display names for the nics
 management_net_name="management"
 workload_net_name="workload"
@@ -82,6 +84,10 @@ checkForExistingOvfenv () {
 escapeString () {
     escaped=$(printf "%q" "$1" | sed 's/\//\\\//g')
     echo "$escaped"
+}
+
+getWorkloadRoutes() {
+  routes=$(ovf-rpctool get.ovf "${workload_routes_key}")
 }
 
 # Persist a string to a file

--- a/ansible/roles/cloudinit/files/var/lib/vmware/ovf-to-cloud-init.sh
+++ b/ansible/roles/cloudinit/files/var/lib/vmware/ovf-to-cloud-init.sh
@@ -358,7 +358,6 @@ if [ ! -f "$first_boot_path" ]; then
     setDataPlaneAPIPort
     writeCAfiles
     writeAnyipConfig
-    writeRouteTableConfig
     writeNetPostConfig
 else
     ensureMetadata

--- a/ansible/roles/cloudinit/files/var/lib/vmware/ovf-to-cloud-init.sh
+++ b/ansible/roles/cloudinit/files/var/lib/vmware/ovf-to-cloud-init.sh
@@ -38,7 +38,7 @@ management_gw_key="network.management_gateway"
 workload_gw_key="network.workload_gateway"
 frontend_gw_key="network.frontend_gateway"
 
-workload_routes_key="network.workload.routes"
+workload_networks_key="network.additional_workload_networks"
 
 # These are the display names for the nics
 management_net_name="management"
@@ -86,8 +86,13 @@ escapeString () {
     echo "$escaped"
 }
 
-getWorkloadRoutes() {
-  routes=$(ovf-rpctool get.ovf "${workload_routes_key}")
+# Extract the additional workload networks and store them in the appropriate file.
+# These CIDRs will be picked up by the route-tables service and the appropriate routes will be created.
+writeWorkloadNetworks() {
+  networks=$(ovf-rpctool get.ovf "${workload_networks_key}")
+  if [ -n "${networks}" ]; then
+    echo "${networks//,/$'\n'}" > /etc/vmware/workload-networks.cfg
+  fi
 }
 
 # Persist a string to a file
@@ -364,6 +369,7 @@ if [ ! -f "$first_boot_path" ]; then
     setDataPlaneAPIPort
     writeCAfiles
     writeAnyipConfig
+    writeWorkloadNetworks
     writeNetPostConfig
 else
     ensureMetadata

--- a/hack/image-build-ova.py
+++ b/hack/image-build-ova.py
@@ -611,12 +611,16 @@ EVALUATION LICENSE.  If You are licensing the Software for evaluation purposes, 
         <Label>2.6. Workload Gateway</Label>
         <Description>The gateway address for the workload network</Description>
       </Property>
+      <Property ovf:key="additional_workload_networks" ovf:type="string" ovf:userConfigurable="true">
+        <Label>2.7. Additional Workload Networks</Label>
+        <Description>(Optional) A comma-separated list of networks in CIDR notation (e.g. 192.168.0.1/24) to the workload networks. These networks must be routable via the Workload Gateway. This list must not include the primary workload network.</Description>
+      </Property>
       <Property ovf:key="frontend_ip" ovf:type="string" ovf:userConfigurable="true" ovf:configuration="frontend">
-        <Label>2.7. Frontend IP</Label>
+        <Label>2.8. Frontend IP</Label>
         <Description>(Optional) The static IP address for the appliance on the Frontend Port Group in CIDR format (Eg. ip/subnet mask bits). This IP must be outside of the Load Balancer IP Range</Description>
       </Property>
       <Property ovf:key="frontend_gateway" ovf:type="string" ovf:userConfigurable="true" ovf:configuration="frontend">
-        <Label>2.8. Frontend Gateway</Label>
+        <Label>2.9. Frontend Gateway</Label>
         <Description>(Optional) The gateway address for the frontend network</Description>
       </Property>
     </ProductSection>


### PR DESCRIPTION
## Problem
Currently we allow users to create additional workloads besides the primary workload network at enablement time. However, HAProxy has no ability to route to these additional workload networks, which means that if service type=LB are created, but that service lives on a network that is not the primary workload network or frontend network, then the packets will not be able to reach their destinations.

## Solution
This change adds an additional field in the OVF wizard called Additional Workload Networks that allows the user to specify a comma-delimited list of networks (specified in CIDR format) to program in its routing table. Route rules are created to reach these networks via the workload networks, because it is a requirement that all workload networks are routable to each other. By using the workload network as the default gateway, we expect the router will deliver the packets to their correct destination.

This change also fixes some minor bugs in the logic to generate the route tables and associated config files.

## Testing
Verified services that live on the additional workload networks besides the primary and frontend networks were reachable and could obtain load balancer frontend IP addresses.