### PR TITLE
Add traceroute to the HAProxy image

### DIFF
--- a/ansible/roles/common/defaults/main.yml
+++ b/ansible/roles/common/defaults/main.yml
@@ -37,6 +37,7 @@ common_photon_rpms:
 - socat
 - tar
 - tcpdump
+- traceroute
 - unzip
 - vim
 


### PR DESCRIPTION
This patch adds the "traceroute" package to the image produced from this repository.

Fixes #23