### PR TITLE
don't add a newline in "BEGIN RSA PRIVATE KEY"

### DIFF
--- a/ansible/roles/cloudinit/files/var/lib/vmware/ovf-to-cloud-init.sh
+++ b/ansible/roles/cloudinit/files/var/lib/vmware/ovf-to-cloud-init.sh
@@ -140,10 +140,12 @@ setHAProxyUserPass() {
 formatCertificate () {
     sed -i \
     -e 's/BEGIN /BEGIN_/g' \
+    -e 's/RSA /RSA_/g' \
     -e 's/PRIVATE /PRIVATE_/g' \
     -e 's/END /END_/g' \
     -e 's/ /\n/g' \
     -e 's/BEGIN_/BEGIN /g' \
+    -e 's/RSA_/RSA /g' \
     -e 's/PRIVATE_/PRIVATE /g' \
     -e 's/END_/END /g' \
     "$1"


### PR DESCRIPTION
I tried creating a VM with this OVA while specifying a ca.crt and ca.key during configuration, but discovered the key was getting mangled.
```
-----BEGIN RSA PRIVATE KEY-----
```
was getting replaced with
```
-----BEGIN RSA
PRIVATE KEY-----
```
which prevented openssl from properly using the user-supplied certificate & key.

made an edit to the setup script to avoid adding a newline after RSA