### PR TITLE
Disable vsock privilege check for protected Cloud-Init variables

### DIFF
--- a/hack/image-build-ova.py
+++ b/hack/image-build-ova.py
@@ -301,6 +301,7 @@ _OVF_TEMPLATE = '''<?xml version='1.0' encoding='UTF-8'?>
       <vmw:Config ovf:required="false" vmw:key="bootOptions.efiSecureBootEnabled" vmw:value="false"/>
       <vmw:Config ovf:required="false" vmw:key="firmware" vmw:value="bios"/>
       <vmw:Config ovf:required="false" vmw:key="virtualICH7MPresent" vmw:value="false"/>
+      <vmw:ExtraConfig ovf:required="false" vmw:key="guest_rpc.auth.cloud-init.set" vmw:value="FALSE"/>
     </VirtualHardwareSection>
     <vmw:StorageSection ovf:required="false" vmw:group="group1">
       <Info>Storage policy group reference</Info>


### PR DESCRIPTION
This patch disables the vsock privilege check for the protected guestinfo variables related to Cloud-Init. The appliance writes to these variables, and this will fail on future vSphere versions that default to requiring this check.

Please note, the method for adding the ExtraConfig value was taken from [this documentation](https://docs.vmware.com/en/VMware-Cloud-Director/10.6/VMware-Cloud-Director-API-Programming-Guide/GUID-09603BC8-E49F-481A-A619-93208F606C3D.html). Customers importing this appliance into vCloud Director may need to add the key from this patch into VCD's list of allowed ExtraConfig keys per the instructions in the aforementioned documentation.